### PR TITLE
Fixes issue where calendar event titles are too long

### DIFF
--- a/frontend/src/scss/calendar.scss
+++ b/frontend/src/scss/calendar.scss
@@ -33,7 +33,7 @@
 
 	padding: 2px 5px;
 	height: 1.4em;
-	line-height: 1.4em;
+
 	margin-top: 2px;
 
 }
@@ -55,7 +55,6 @@ $calendar-event-rounding: 3px;
 
 		font-size: x-small;
 
-		white-space: nowrap;
 
 	}
 


### PR DESCRIPTION
- Removes line-height restriction and allows word-wrap

This may or may not be useful - I just wanted to django again... :) Who knows, maybe you're planning to ellipse the events titles instead.
![screen shot 2015-10-13 at 21 23 08](https://cloud.githubusercontent.com/assets/2001446/10467250/a68707e0-71f0-11e5-96ac-18f88c0218a4.png) -> 
![screen shot 2015-10-13 at 21 22 31](https://cloud.githubusercontent.com/assets/2001446/10467260/b3a143dc-71f0-11e5-8b9f-bb7b39500c44.png)
